### PR TITLE
fix: remove semicolon from css file

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,4 @@
 .react-split-text {
     display: inline-block;
     white-space: pre-wrap;
-};
+}


### PR DESCRIPTION
This PR removes the semicolon at the end of the CSS file as it breaks the selector immediately after when importing it:

```css
@import '@moxy/react-split-text/dist/index.css';

.blue {
	color: blue;
}

.red {
	color: red;
}
```

The semicolon would cause the `blue` class to be ignored. 

